### PR TITLE
ChatSpaceデータベースの設計をREADMEに記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -22,10 +22,47 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false|
+|password|string|null: false|
+|username|string|null: false|
+
+### Association
+- has_many :groups, through: :groups_users
+- has_many :messages
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|groupname|string|null: false|
+
+### Association
+- has_many :users, through: :groups_users
+- has_many :messages
+
+
 ## groups_usersテーブル
 
 |Column|Type|Options|
 |------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text||
+|image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|groupname|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :users, through: :groups_users

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Things you may want to cover:
 ### Association
 - has_many :users, through: :groups_users
 - has_many :messages
+- has_many :groups_users
 
 
 ## groups_usersテーブル

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Things you may want to cover:
 - has_many :groups, through: :groups_users
 - has_many :messages
 
+
 ## groupsテーブル
 
 |Column|Type|Options|

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Things you may want to cover:
 ### Association
 - has_many :groups, through: :groups_users
 - has_many :messages
-
+- has_many :groups_users
 
 ## groupsテーブル
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Things you may want to cover:
 |------|----|-------|
 |email|string|null: false|
 |password|string|null: false|
-|username|string|null: false|
+|name|string|null: false|
 
 ### Association
 - has_many :groups, through: :groups_users


### PR DESCRIPTION
# WHAT
ChatSpaceデータベースの設計をREADMEに記述しました。users、groups、groups_users、messagesの4つのテーブルとその属性、オプション、アソシエーションを設計しました。

# WHY
ChatSpaceにデータベースを構築するため。カリキュラムを進めるため。